### PR TITLE
update conditional checking for configuration

### DIFF
--- a/lua/lsputil/codeAction.lua
+++ b/lua/lsputil/codeAction.lua
@@ -74,10 +74,10 @@ local code_action_handler = function(_,_,actions)
 		opts.width = tmp.width
 		opts.additional_keymaps = tmp.keymaps or opts.additional_keymaps
 		if tmp.list then
-			if not tmp.list.numbering == nil then
+			if not (tmp.list.numbering == nil) then
 				opts.list.numbering = tmp.list.numbering
 			end
-			if not tmp.list.border == nil then
+			if not (tmp.list.border == nil) then
 				opts.list.border = tmp.list.border
 			end
 			opts.list.title = tmp.list.title or opts.list.title

--- a/lua/lsputil/locations.lua
+++ b/lua/lsputil/locations.lua
@@ -97,19 +97,19 @@ local function references_handler(_, _, locations,_,bufnr)
 		opts.width = tmp.width
 		opts.additional_keymaps = tmp.keymaps or opts.additional_keymaps
 		if tmp.list then
-			if not tmp.list.numbering == nil then
+			if not (tmp.list.numbering == nil) then
 				opts.list.numbering = tmp.list.numbering
 			end
-			if not tmp.list.border == nil then
+			if not (tmp.list.border == nil) then
 				opts.list.border = tmp.list.border
 			end
 			opts.list.title = tmp.list.title or opts.list.title
 		end
 		if tmp.preview then
-			if not tmp.preview.numbering == nil then
+			if not (tmp.preview.numbering == nil) then
 				opts.preview.numbering = tmp.preview.numbering
 			end
-			if not tmp.preview.border == nil then
+			if not (tmp.preview.border == nil) then
 				opts.preview.border = tmp.preview.border
 			end
 			opts.preview.title = tmp.preview.title or opts.preview.title
@@ -175,19 +175,19 @@ local definition_handler = function(_,_,locations, _, bufnr)
 				opts.width = tmp.width
 				opts.additional_keymaps = tmp.keymaps or opts.additional_keymaps
 				if tmp.list then
-					if not tmp.list.numbering == nil then
+					if not (tmp.list.numbering == nil) then
 						opts.list.numbering = tmp.list.numbering
 					end
-					if not tmp.list.border == nil then
+					if not (tmp.list.border == nil) then
 						opts.list.border = tmp.list.border
 					end
 					opts.list.title = tmp.list.title or opts.list.title
 				end
 				if tmp.preview then
-					if not tmp.preview.numbering == nil then
+					if not (tmp.preview.numbering == nil) then
 						opts.preview.numbering = tmp.preview.numbering
 					end
-					if not tmp.preview.border == nil then
+					if not (tmp.preview.border == nil) then
 						opts.preview.border = tmp.preview.border
 					end
 					opts.preview.title = tmp.preview.title or opts.preview.title

--- a/lua/lsputil/symbols.lua
+++ b/lua/lsputil/symbols.lua
@@ -96,19 +96,19 @@ local function symbol_handler(_, _, result, _, bufnr)
 		opts.width = tmp.width
 		opts.additional_keymaps = tmp.keymaps or opts.additional_keymaps
 		if tmp.list then
-			if not (tmp.list.numbering) == nil then
+			if not (tmp.list.numbering == nil) then
 				opts.list.numbering = tmp.list.numbering
 			end
-			if not (tmp.list.border) == nil then
+			if not (tmp.list.border == nil) then
 				opts.list.border = tmp.list.border
 			end
 			opts.list.title = tmp.list.title or opts.list.title
 		end
 		if tmp.preview then
-			if not (tmp.preview.numbering) == nil then
+			if not (tmp.preview.numbering == nil) then
 				opts.preview.numbering = tmp.preview.numbering
 			end
-			if not (tmp.preview.border) == nil then
+			if not (tmp.preview.border == nil) then
 				opts.preview.border = tmp.preview.border
 			end
 			opts.preview.title = tmp.preview.title or opts.preview.title

--- a/lua/lsputil/symbols.lua
+++ b/lua/lsputil/symbols.lua
@@ -96,19 +96,19 @@ local function symbol_handler(_, _, result, _, bufnr)
 		opts.width = tmp.width
 		opts.additional_keymaps = tmp.keymaps or opts.additional_keymaps
 		if tmp.list then
-			if not tmp.list.numbering == nil then
+			if not (tmp.list.numbering) == nil then
 				opts.list.numbering = tmp.list.numbering
 			end
-			if not tmp.list.border == nil then
+			if not (tmp.list.border) == nil then
 				opts.list.border = tmp.list.border
 			end
 			opts.list.title = tmp.list.title or opts.list.title
 		end
 		if tmp.preview then
-			if not tmp.preview.numbering == nil then
+			if not (tmp.preview.numbering) == nil then
 				opts.preview.numbering = tmp.preview.numbering
 			end
-			if not tmp.preview.border == nil then
+			if not (tmp.preview.border) == nil then
 				opts.preview.border = tmp.preview.border
 			end
 			opts.preview.title = tmp.preview.title or opts.preview.title


### PR DESCRIPTION
I was trying to set-up the custom configuration options for the windows and found that they would not take any of the configuration no matter what I did.

This just puts `()` around the `x == nil` checks before the negation with `not` and it'll evaluate in the order we expect it to.