### PR TITLE
Custom filetype for lsputils buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ Add following to init.vim lua chunk as:
 |\<Down\>|Selects next item                          |
 |\<Up\>  |Selects previous item                      |
   
+## Custom Filetypes
+
+nvim-lsputils export some custom filetypes for their created buffer.
+This enables users to do customization for nvim-lsputil buffers.
+
+Custom filetypes are:
+
+- For codeaction:
+
+    - lsputil_codeaction_list (Represents codeaction list)
+    - lsputil_codeaction_prompt (Represents codeaction prompt) (If enabled)
+
+- For symbols (workspace and document symbols):
+
+    - lsputil_symbols_list (Represents symbols list)
+    - lsputil_symbols_preview (Represents symbols preview)
+    - lsputil_symbols_prompt (Represents symbols prompt)
+
+- For locations (definition, declaration, references, implementation):
+
+    - lsputil_locations_list (Represents locations list)
+    - lsputil_locations_preview (Represents locations preview)
+    - lsputil_locations_prompt (Represents locations prompt)
 
 ## Custom Options
 

--- a/lua/lsputil/codeAction.lua
+++ b/lua/lsputil/codeAction.lua
@@ -37,7 +37,6 @@ local opts = {
 }
 util.handleGlobalVariable(vim.g.lsp_utils_codeaction_opts, opts)
 
-
 -- codeAction event callback handler
 local code_action_handler = function(_,_,actions)
     if actions == nil or vim.tbl_isempty(actions) then
@@ -67,6 +66,10 @@ local code_action_handler = function(_,_,actions)
     actionModule.popup = popfix:new(opts)
     if not actionModule.popup then
 	actionModule.actionBuffer = nil
+    end
+    util.setFiletype(actionModule.popup.list.buffer, 'lsputil_codeaction_list')
+    if actionModule.popup.prompt then
+	util.setFiletype(actionModule.popup.prompt.buffer, 'lsputil_codeaction_prompt')
     end
     opts.data = nil
 end

--- a/lua/lsputil/locations.lua
+++ b/lua/lsputil/locations.lua
@@ -79,6 +79,15 @@ local function references_handler(_, _, locations,_,bufnr)
     if not action.popup then
 	action.items = nil
     end
+    if action.popup.list then
+	util.setFiletype(action.popup.list.buffer, 'lsputil_locations_list')
+    end
+    if action.popup.preview then
+	util.setFiletype(action.popup.preview.buffer, 'lsputil_locations_preview')
+    end
+    if action.popup.prompt then
+	util.setFiletype(action.popup.prompt.buffer, 'lsputil_locations_prompt')
+    end
     opts.data = nil
 end
 
@@ -109,6 +118,15 @@ local definition_handler = function(_,_,locations, _, bufnr)
 	    action.popup = popfix:new(opts)
 	    if not action.popup then
 		action.items = nil
+	    end
+	    if action.popup.list then
+		util.setFiletype(action.popup.list.buffer, 'lsputil_locations_list')
+	    end
+	    if action.popup.preview then
+		util.setFiletype(action.popup.preview.buffer, 'lsputil_locations_preview')
+	    end
+	    if action.popup.prompt then
+		util.setFiletype(action.popup.prompt.buffer, 'lsputil_locations_prompt')
 	    end
 	    opts.data = nil
 	else

--- a/lua/lsputil/symbols.lua
+++ b/lua/lsputil/symbols.lua
@@ -78,6 +78,15 @@ local function symbol_handler(_, _, result, _, bufnr)
     if not action.popup then
 	action.items = nil
     end
+    if action.popup.list then
+	util.setFiletype(action.popup.list.buffer, 'lsputil_symbols_list')
+    end
+    if action.popup.preview then
+	util.setFiletype(action.popup.preview.buffer, 'lsputil_symbols_preview')
+    end
+    if action.popup.prompt then
+	util.setFiletype(action.popup.prompt.buffer, 'lsputil_symbols_prompt')
+    end
     opts.data = nil
 end
 

--- a/lua/lsputil/util.lua
+++ b/lua/lsputil/util.lua
@@ -151,10 +151,15 @@ local function handleGlobalVariable(var, opts)
     end
 end
 
+local function setFiletype(buffer, type)
+    vim.api.nvim_buf_set_option(buffer, 'filetype', type)
+end
+
 
 return{
     get_data_from_file = get_data_from_file,
     get_relative_path = get_relative_path,
     handleGlobalVariable = handleGlobalVariable,
+    setFiletype = setFiletype
 }
 


### PR DESCRIPTION
As @akinsho mentioned in #18

> an advantage to still adding a FT could be for user customization e.g.
    I might want the windows to be yellow or something

Having custom filetypes for nvim-lsputils buffer would enable the user to customize
the lsputils buffer on basis of filetypes.