### PR TITLE
pressing number in normal mode would directly apply codeaction

### DIFF
--- a/lua/lsputil/codeAction.lua
+++ b/lua/lsputil/codeAction.lua
@@ -3,24 +3,26 @@ local util = require'lsputil.util'
 local actionModule = require'lsputil.actions'
 
 -- default keymaps provided by nvim-lsputils
-local keymaps = {
-    i = {
-	['<C-n>'] = actionModule.codeaction_next,
-	['<C-p>'] = actionModule.codeaction_prev,
-	['<CR>'] = actionModule.codeaction_fix,
-	['<Down>'] = actionModule.select_next,
-	['<Up>'] = actionModule.select_prev,
-    },
-    n = {
-	['<CR>'] = actionModule.codeaction_fix,
-	['<Esc>'] = actionModule.codeaction_cancel,
-	['q'] = actionModule.codeaction_cancel,
-	['j'] = actionModule.codeaction_next,
-	['k'] = actionModule.codeaction_prev,
-	['<Down>'] = actionModule.select_next,
-	['<Up>'] = actionModule.select_prev,
+local function createKeymaps()
+    return {
+	i = {
+	    ['<C-n>'] = actionModule.codeaction_next,
+	    ['<C-p>'] = actionModule.codeaction_prev,
+	    ['<CR>'] = actionModule.codeaction_fix,
+	    ['<Down>'] = actionModule.select_next,
+	    ['<Up>'] = actionModule.select_prev,
+	},
+	n = {
+	    ['<CR>'] = actionModule.codeaction_fix,
+	    ['<Esc>'] = actionModule.codeaction_cancel,
+	    ['q'] = actionModule.codeaction_cancel,
+	    ['j'] = actionModule.codeaction_next,
+	    ['k'] = actionModule.codeaction_prev,
+	    ['<Down>'] = actionModule.select_next,
+	    ['<Up>'] = actionModule.select_prev,
+	}
     }
-}
+end
 
 -- opts required for popfix
 local opts = {
@@ -33,7 +35,6 @@ local opts = {
     callbacks = {
 	close = actionModule.codeaction_cancel_handler
     },
-    keymaps = keymaps,
 }
 util.handleGlobalVariable(vim.g.lsp_utils_codeaction_opts, opts)
 
@@ -60,6 +61,13 @@ local code_action_handler = function(_,_,actions)
 	    width = #str
 	end
     end
+    local keymaps = createKeymaps()
+    if not opts.prompt then
+	for k,_ in ipairs(data) do
+	    keymaps.n[tostring(k)] = k..'G<CR>'
+	end
+    end
+    opts.keymaps = keymaps
     opts.width = width + 5
     opts.height = opts.height or #data
     opts.data = data


### PR DESCRIPTION
As discussed in #18, @akinsho mentioned:

> I had assumed it worked the same way as in coc that pressing the number would
 activate the selection at the line number.

 This pull request aims to trigger codeaction as we press the number.  I
 initially thought that it would compromise some vim features like searching
 using ``/``. However, that is not true. It's just in the case of coc I guess. They
 have implemented it some other way or I am unaware of it.

 However, the same behavior with fuzzy mode doesn't seem to be intuitive and
 hence, this pull request would only impact popup mode, not fuzzy mode.