### PR TITLE
Fix nvim version detection in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It can be installed with any plugin manager. For example with vim-plug:
 Add following to init.vim lua chunk as:
 
 	lua <<EOF
-    if vim.fn.has('nvim-0.6') == 1 then
+    if vim.fn.has('nvim-0.5.1') == 1 then
         vim.lsp.handlers['textDocument/codeAction'] = require'lsputil.codeAction'.code_action_handler
         vim.lsp.handlers['textDocument/references'] = require'lsputil.locations'.references_handler
         vim.lsp.handlers['textDocument/definition'] = require'lsputil.locations'.definition_handler


### PR DESCRIPTION
The handler signature changed in nvim-0.5.1 already (https://github.com/neovim/neovim/pull/15504).
It's probably a good idea to keep this in the README for people not on rolling release distros though.