### PR TITLE
Fix string format line for preview with `bat`

### DIFF
--- a/lua/lsputil/actions.lua
+++ b/lua/lsputil/actions.lua
@@ -45,7 +45,7 @@ function M.selection_handler(index)
     if startPoint <= 0 then
 	startPoint = item.lnum
     end
-    local cmd = string.format('bat %s --color=always --paging=always --plain -n --pager="less -RS" -H %s -r %s:', item.filename, item.lnum, startPoint)
+    local cmd = string.format('bat "%s" --color=always --paging=always --plain -n --pager="less -RS" -H %s -r %s:', item.filename, item.lnum, startPoint)
     return {
 	cmd = cmd
     }


### PR DESCRIPTION
The current preview command does not put double quotes to the 'item.filename', which will cause an error when passed to `bat` if the file path contains space.
Change the line
```
local cmd = string.format('bat %s --color=always --paging=always --plain -n --pager="less -RS" -H %s -r %s:', item.filename, item.lnum, startPoint)
```
to
```
local cmd = string.format('bat "%s" --color=always --paging=always --plain -n --pager="less -RS" -H %s -r %s:', item.filename, item.lnum, startPoint)
```