### PR TITLE
Jump from the reference window to the start of the entry

### DIFF
--- a/lua/lsputil/actions.lua
+++ b/lua/lsputil/actions.lua
@@ -17,7 +17,7 @@ function M.close_selected_handler(index, command)
 	    start = {
 		line = item.lnum - 1,
 		--TODO: robust character column
-		character = item.col
+		character = item.col - 1
 	    }
 	}
     }


### PR DESCRIPTION
It used to jump to the next symbol on the right of the correct column