### PR TITLE
Annotate locations_to_items() and friends with valid offset_encoding

### DIFF
--- a/lua/lsputil/actions.lua
+++ b/lua/lsputil/actions.lua
@@ -1,5 +1,6 @@
 local M = {}
 local api = vim.api
+local offset_encoding = "utf-8"
 -- close handler
 -- jump to location in a new vertical split
 -- according to index and result returned by server.
@@ -30,7 +31,7 @@ function M.close_selected_handler(index, command)
 	local buffer = api.nvim_get_current_buf()
         vim.cmd(string.format(":tab sb %d", buffer))
     end
-    vim.lsp.util.jump_to_location(location)
+    vim.lsp.util.jump_to_location(location, offset_encoding)
     vim.cmd(':normal! zz')
     M.items = nil
 end
@@ -94,6 +95,9 @@ function M.close_tab(self)
 end
 
 function M.close_edit(self)
+    local buf = vim.fn.winbufnr(self.originalWindow)
+    local clients = vim.lsp.get_clients({bufnr = buf})
+    offset_encoding = #clients > 0 and clients[1].offset_encoding or "utf-8"
     self:close(M.close_selected_handler)
 end
 
@@ -107,7 +111,7 @@ function M.codeaction_selection_handler(index)
     local action = M.actionBuffer[index]
     if action.edit or type(action.command) == "table" then
 	if action.edit then
-	    vim.lsp.util.apply_workspace_edit(action.edit)
+	    vim.lsp.util.apply_workspace_edit(action.edit, offset_encoding)
 	end
 	if type(action.command) == "table" then
 	    vim.lsp.buf.execute_command(action.command)

--- a/lua/lsputil/locations.lua
+++ b/lua/lsputil/locations.lua
@@ -64,10 +64,12 @@ local function references_handler(_, locations, ctx, _)
 	print 'Busy with some LSP popup'
 	return
     end
+    local client = vim.lsp.get_client_by_id(ctx.client_id)
+    local offset_encoding = client.offset_encoding
     local bufnr = ctx.bufnr
     local data = {}
     local filename = vim.api.nvim_buf_get_name(bufnr)
-    action.items = vim.lsp.util.locations_to_items(locations)
+    action.items = vim.lsp.util.locations_to_items(locations, offset_encoding)
     for i, item in pairs(action.items) do
 	data[i] = item.text
 	if filename ~= item.filename then
@@ -101,6 +103,8 @@ local definition_handler = function(_,locations, ctx, _)
     if locations == nil or vim.tbl_isempty(locations) then
 	return
     end
+    local client = vim.lsp.get_client_by_id(ctx.client_id)
+    local offset_encoding = client.offset_encoding
     local bufnr = ctx.bufnr
     if vim.tbl_islist(locations) then
 	if #locations > 1 then
@@ -110,7 +114,7 @@ local definition_handler = function(_,locations, ctx, _)
 	    end
 	    local data = {}
 	    local filename = vim.api.nvim_buf_get_name(bufnr)
-	    action.items = vim.lsp.util.locations_to_items(locations)
+	    action.items = vim.lsp.util.locations_to_items(locations, offset_encoding)
 	    for i, item in pairs(action.items) do
 		data[i] = item.text
 		if filename ~= item.filename then
@@ -138,10 +142,10 @@ local definition_handler = function(_,locations, ctx, _)
 	    end
 	    opts.data = nil
 	else
-	    vim.lsp.util.jump_to_location(locations[1])
+	    vim.lsp.util.jump_to_location(locations[1], offset_encoding)
 	end
     else
-	vim.lsp.util.jump_to_location(locations)
+	vim.lsp.util.jump_to_location(locations, offset_encoding)
     end
 end
 


### PR DESCRIPTION
In Neovim 0.10, lack of the offset encoding value leads to warnings like `show_document must be called with valid offset encoding`. This commit fixes such warnings. Note that the fix in actions.lua is rather insufficient as it involves a global variable that must be adjusted on every usage which is not the case right now: it gets adjusted only in `M.close_edit()`.